### PR TITLE
Content - Default regtest port changed 18332->19898

### DIFF
--- a/_includes/devdoc/dash-core/rpcs/intro.md
+++ b/_includes/devdoc/dash-core/rpcs/intro.md
@@ -37,7 +37,7 @@ languages lacking a suitable native client. The remainder of this section
 describes the Dash Core RPC protocol in detail.
 
 The Dash Core RPC service listens for HTTP `POST` requests on port 9998 in
-mainnet mode, 19998 in testnet, or 18332 in regtest mode. The port number can be changed
+mainnet mode, 19998 in testnet, or 19898 in regtest mode. The port number can be changed
 by setting `rpcport` in `dash.conf`. By default the RPC service binds to your
 server's [localhost][Localhost] loopback
 network<!--noref--> interface so it's not accessible from other servers.

--- a/_includes/devdoc/example_intro.md
+++ b/_includes/devdoc/example_intro.md
@@ -21,7 +21,7 @@ Once installed, you'll have access to three programs: `dashd`,
 
 * `dashd` is more useful for programming: it provides a full peer
   which you can interact with through RPCs to port 9998 (or 19998
-  for testnet / 18332 for regtest).
+  for testnet / 19898 for regtest).
 
 * `dash-cli` allows you to send RPC commands to `dashd` from the
   command line.  For example, `dash-cli help`

--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -38,8 +38,8 @@ The following constants and defaults are taken from Dash Core's
 |---------|--------------|-----------------------------------------------|---------------
 | Mainnet | 9999         | 0xBD6B0CBF  | 0xBF0C6BBD                      | 0x1e0ffff0
 | Testnet | 19999        | 0xFFCAE2CE  | 0xCEE2CAFF                      | 0x1e0ffff0
-| Regtest | 19994        | 0xDCB7C1FC  | 0xFCC1B7DC                      | 0x207fffff
 | Devnet  | User-defined | 0xCEFFCAE2  | 0xE2CAFFCE                      | 0x207fffff
+| Regtest | 19899        | 0xDCB7C1FC  | 0xFCC1B7DC                      | 0x207fffff
 
 Note: the testnet start string and nBits above are for testnet3.
 

--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -39,7 +39,7 @@ The following constants and defaults are taken from Dash Core's
 | Mainnet | 9999         | 0xBD6B0CBF  | 0xBF0C6BBD                      | 0x1e0ffff0
 | Testnet | 19999        | 0xFFCAE2CE  | 0xCEE2CAFF                      | 0x1e0ffff0
 | Regtest | 19899        | 0xDCB7C1FC  | 0xFCC1B7DC                      | 0x207fffff
-| Devnet  | User-defined (default 19799)| 0xCEFFCAE2  | 0xE2CAFFCE                      | 0x207fffff
+| Devnet  | User-defined (default 19799) | 0xCEFFCAE2  | 0xE2CAFFCE                      | 0x207fffff
 
 Note: the testnet start string and nBits above are for testnet3.
 

--- a/_includes/devdoc/ref_p2p_networking.md
+++ b/_includes/devdoc/ref_p2p_networking.md
@@ -38,8 +38,8 @@ The following constants and defaults are taken from Dash Core's
 |---------|--------------|-----------------------------------------------|---------------
 | Mainnet | 9999         | 0xBD6B0CBF  | 0xBF0C6BBD                      | 0x1e0ffff0
 | Testnet | 19999        | 0xFFCAE2CE  | 0xCEE2CAFF                      | 0x1e0ffff0
-| Devnet  | User-defined | 0xCEFFCAE2  | 0xE2CAFFCE                      | 0x207fffff
 | Regtest | 19899        | 0xDCB7C1FC  | 0xFCC1B7DC                      | 0x207fffff
+| Devnet  | User-defined (default 19799)| 0xCEFFCAE2  | 0xE2CAFFCE                      | 0x207fffff
 
 Note: the testnet start string and nBits above are for testnet3.
 


### PR DESCRIPTION
Avoids conflict with bitcoin
Related to dashpay/dash#3064