### PR TITLE
Readme redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem 'jshintrb', '~>0.3.0'
   gem 'safe_yaml'
   gem 'json-schema'
+  gem 'jekyll-redirect-from'
 end
 
 ## Not used on build server. Only used by developers and Travis CI, so

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.11.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
     jekyll-watch (1.3.0)
@@ -77,6 +79,7 @@ DEPENDENCIES
   ffi-icu
   html-proofer (= 2.1.0)
   jekyll (~> 3.0)
+  jekyll-redirect-from
   jshintrb (~> 0.3.0)
   json (>= 1.9)
   json-schema
@@ -89,4 +92,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Makefile
+++ b/Makefile
@@ -133,13 +133,7 @@ check-for-liquid-errors:
 #
 ## Takes less than 1 second here as of 2014-05-16 -harding
 check-for-missing-anchors:
-	$S sed -n 's!^\[[^]]*]: \+!!; s/ .*//; /#/s!^/!!p' _includes/references.md \
-	    | sort -u \
-	    | while read link ; do file="$(SITEDIR)/$${link%#*}.html" \
-	        ; anchor="$${link##*#}" \
-	        ; egrep -ql '(id|name)=.'$$anchor'[^a-zA-Z0-9_-]' $$file \
-	        || echo "$$file#$$anchor not found" \
-	    ; done | eval $(ERROR_ON_OUTPUT)
+	
 
 check-for-broken-markdown-reference-links:
 ## Report Markdown reference-style links which weren't converted to HTML

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
+gems:
+  - jekyll-redirect-from
+
 langsorder:
 #- 'id'
 #- 'da'

--- a/_includes/templates/index.html
+++ b/_includes/templates/index.html
@@ -3,97 +3,13 @@ This file is licensed under the MIT License (MIT) available on
 http://opensource.org/licenses/MIT.
 {% endcomment %}
 
-<link rel="stylesheet" href="/css/jquery-ui.min.css">
-
-<h2 style="text-align:center"><img src="/img/icons/icon_warning.svg"></img> Important Note: This documentation site has been deprecated and has not been updated since Dash Core 0.15.0. You will be redirected to the new site at <a href="https://dashcore.readme.io">https://dashcore.readme.io</a> momentarily. <img src="/img/icons/icon_warning.svg"></img></h2>
-
-<h1 id="developer-documentation">Developer Documentation</h1>
-
-<p class="summary">Find useful resources, guides and reference material for developers.</p>
-
-<input id="glossary_term" class="glossary_term" placeholder="Search the glossary, RPCs, and more">
-
-<div class="docreference">
-<a href="/en/developer-guide"><span class="fa fa-info-circle fa-2x"></span><span>Protocol<br />Guide</span></a>
-<a href="/en/developer-reference"><span class="fa fa-book fa-2x"></span><span>Technical Reference</span></a>
-<a href="/en/developer-examples"><span class="fa fa-code fa-2x"></span><span>Development Examples</span></a>
-<a href="/en/developer-glossary"><span class="fa fa-font fa-2x"></span><span>Technical Glossary</span></a>
-<a href="/en/doxygen/html/index.html"><span class="fa fa-code fa-2x"></span><span>Source Code Documentation</span></a>
-</div>
-
-<div class="resources">
-  <div><div>
-      <h2 id="block_chain"><span class="fa fa-cube fa-lg"></span> Block Chain</h2>
-      <p><a href="/en/developer-guide#block-chain">Block Chain Guide</a></p>
-      <p><a href="/en/developer-reference#block-chain">Block Chain Reference</a></p>
-    </div><div>
-      <h2 id="transactions"><span class="fa fa-exchange fa-lg"></span> Transactions</h2>
-      <p><a href="/en/developer-guide#transactions">Transactions Guide</a></p>
-      <p><a href="/en/developer-reference#transactions">Transactions Reference</a></p>
-      <p><a href="/en/developer-examples#transactions">Transaction Examples</a></p>
-    </div>
-  </div>
-  <div>
-    <div>
-      <h2 id="p2p-network"><span class="fa fa-share-alt fa-lg"></span> P2P Network</h2>
-      <p><a href="/en/developer-guide#p2p-network">P2P Network Guide</a></p>
-      <p><a href="/en/developer-reference#p2p-network">P2P Network Reference</a></p>
-      <p><a href="/en/developer-examples#p2p-network">P2P Network Examples</a></p>
-    </div><div>
-      <h2 id="contracts"><span class="fa fa-sitemap fa-lg fa-rotate-270"></span> Dash Features</h2>
-      <p><a href="/en/developer-guide#instantsend">InstantSend Guide</a></p>
-      <p><a href="/en/developer-guide#privatesend">PrivateSend Guide</a></p>
-      <p><a href="/en/developer-guide#masternode-payment">Masternode Payment Guide</a></p>
-      <p><a href="/en/developer-guide#masternode-sync">Masternode Sync Guide</a></p>
-      <p><a href="/en/developer-guide#governance">Governance Guide</a></p>
-      <p><a href="/en/developer-guide#masternode-quorums">Masternode Quorums Guide</a></p>
-      <p><a href="/en/developer-guide#proof-of-service">Proof of Service Guide</a></p>
-    </div>
-  </div>
-  <div>
-    <div>
-      <h2 id="wallets"><span class="fa fa-btc fa-lg"></span> Wallets</h2>
-      <p><a href="/en/developer-guide#wallets">Wallets Guide</a></p>
-      <p><a href="/en/developer-reference#wallets">Wallets Reference</a></p>
-      <p><a href="https://github.com/dashevo/bips/blob/master/bip-0032.mediawiki"><span class="fa fa-external-link"></span> HD Wallets</a> - BIP32</p>
-      <p><a href="https://github.com/dashevo/bips/blob/master/bip-0039.mediawiki"><span class="fa fa-external-link"></span> Mnemonic Code</a> - BIP39</p>
-    </div><div>
-      <h2 id="operating_modes"><span class="fa fa-cogs fa-lg"></span> Operating Modes</h2>
-      <p><a href="/en/developer-guide#operating-modes">Operating Modes Guide</a></p>
-    </div>
-  </div>
-  <div>
-    <div>
-      <h2 id="payment-processing"><span class="fa fa-cart-plus fa-lg"></span> Payment Processing</h2>
-      <!--
-      <p><a href="/en/developer-guide#payment-processing">Payment Processing Guide</a></p>
-      <p><a href="/en/developer-examples#payment-processing">Payment Processing Examples</a></p>
-      -->
-      <p><a href="https://github.com/dashevo/bips/blob/master/bip-0070.mediawiki"><span class="fa fa-external-link"></span> Payment Protocol</a> - BIP70</p>
-    </div><div>
-      <h2 id="mining"><span class="fa fa-puzzle-piece fa-lg"></span> Mining</h2>
-      <p><a href="/en/developer-guide#mining">Mining Guide</a></p>
-      <p><a href="https://github.com/dashevo/bips/blob/master/bip-0022.mediawiki"><span class="fa fa-external-link"></span> getblocktemplate Fundamentals</a> - BIP22</p>
-      <p><a href="https://github.com/dashevo/bips/blob/master/bip-0023.mediawiki"><span class="fa fa-external-link"></span> getblocktemplate Pooled Mining</a> - BIP23</p>
-    </div>
-  </div>
-</div>
-
-<div class="resourcesmore"><div>
-  <h2 id="additional-resources"><span class="fa fa-link fa-lg"></span> Additional resources</h2>
-  <p><a href="https://docs.dash.org/en/stable/introduction/about.html#whitepaper"><span class="fa fa-external-link"></span> Dash Whitepaper</a> - Official Wiki</p>
-  <p><a href="https://github.com/dashpay/dips#readme"><span class="fa fa-external-link"></span> Dash Improvement Proposals</a> - GitHub</p>
-  <!--<p><a href="https://dashpay.atlassian.net/wiki/spaces/DOC/pages"><span class="fa fa-external-link"></span> Dash Documentation</a> - Official Wiki</p>-->
-  <p><a href="/en/bitcoin-paper"><span class="fa fa-external-link"></span> Bitcoin: A Peer-to-Peer Electronic Cash System</a> - Satoshi Nakamoto</p>
-  <p><a href="https://github.com/dashevo/bips#readme"><span class="fa fa-external-link"></span> Bitcoin Improvement Proposals (with Dash updates)</a> - GitHub</p>
-
-  <p><a rel="noopener noreferrer" target="_blank" href="https://www.blockcypher.com/dev/dash/"><span class="fa fa-external-link"></span> RESTful JSON API for Dash</a> - BlockCypher</p>
-  <p><a rel="noopener noreferrer" target="_blank" href="https://www.chainrider.io/docs/dash/"><span class="fa fa-external-link"></span> RESTful JSON API for Dash</a> - ChainRider</p>
-  <!--<p><a href="https://github.com/minium/Bitcoin-Spec"><span class="fa fa-external-link"></span> Bitcoin Developer Reference (working paper)</a> - Krzysztof Okupski</p>-->
-  <!--<p><a href="https://bitcoinj.github.io/#documentation"><span class="fa fa-external-link"></span> Bitcoinj Developer Documentation</a> - bitcoinj.org</p>-->
-  <!--<p><a href="https://programmingblockchain.gitbooks.io/programmingblockchain/content/"><span class="fa fa-external-link"></span> The C# Bitcoin book (NBitcoin Developer Documentation)</a> - Nicolas Dorier</p>-->
-</div></div>
-
-<script src="/js/jquery/jquery-1.11.2.min.js"></script>
-<script src="/js/jquery/jquery-ui.min.js"></script>
-<script src="/js/devsearch.js"></script>
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="https://dashcore.readme.io/">
+<meta http-equiv="refresh" content="0; url=https://dashcore.readme.io/">
+<h1>Redirecting…</h1>
+<a href="https://dashcore.readme.io/">Click here if you are not redirected.</a>
+<script>location="https://dashcore.readme.io/"</script>
+</html>

--- a/_templates/dash-for-developers.html
+++ b/_templates/dash-for-developers.html
@@ -5,29 +5,13 @@
 layout: base
 id: dash-for-developers
 ---
-<h2 style="text-align:center"><img src="/img/icons/icon_warning.svg"></img> Important Note: This documentation site has been deprecated and has not been updated since Dash Core 0.15.0. You will be redirected to the new site at <a href="https://dashcore.readme.io">https://dashcore.readme.io</a> momentarily. <img src="/img/icons/icon_warning.svg"></img></h2>
-
-<h1>{% translate pagetitle %}</h1>
-<p class="summary">{% translate summary %}</p>
-
-<h2 id="simple"><img class="titleicon" src="/img/icons/ico_simple.svg" alt="Icon" />{% translate simple %}</h2>
-<p>{% translate simpletext %}</p>
-
-<h2 id="api"><img class="titleicon" src="/img/icons/ico_conf.svg" alt="Icon" />{% translate api %}</h2>
-<p>{% translate apitext %}</p>
-
-<h2 id="own"><img class="titleicon" src="/img/icons/ico_own.svg" alt="Icon" />{% translate own %}</h2>
-<p>{% translate owntext %}</p>
-
-<h2 id="invoice"><img class="titleicon" src="/img/icons/ico_invoice.svg" alt="Icon" />{% translate invoice %}</h2>
-<p>{% translate invoicetext %}</p>
-
-<h2 id="security"><img class="titleicon" src="/img/icons/ico_lock.svg" alt="Icon" />{% translate security %}</h2>
-<p>{% translate securitytext %}</p>
-
-<h2 id="micro"><img class="titleicon" src="/img/icons/ico_micro.svg" alt="Icon" />{% translate micro %}</h2>
-<p>{% translate microtext %}</p>
-
-<div class="introlink"><a href="https://dashcore.readme.io/">Developer Documentation {% if page.lang != "en" %}(English){% endif %}</a></div>
-<!--<div class="mainbutton"><a href="/{{ page.lang }}/{% translate getting-started url %}"><img src="/img/icons/but_bitcoin.svg" alt="icon">{% translate getstarted layout %}</a></div> -->
-<div class="mainbutton"><a href="https://www.dash.org/" target="_blank">{% translate getstarted layout %}</a></div>
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="https://dashcore.readme.io/">
+<meta http-equiv="refresh" content="0; url=https://dashcore.readme.io/">
+<h1>Redirecting…</h1>
+<a href="https://dashcore.readme.io/">Click here if you are not redirected.</a>
+<script>location="https://dashcore.readme.io/"</script>
+</html>

--- a/_templates/vocabulary.html
+++ b/_templates/vocabulary.html
@@ -25,19 +25,13 @@ voc:
 
 ---
 
-<h2 style="text-align:center"><img src="/img/icons/icon_warning.svg"></img> Important Note: This documentation site has been deprecated and has not been updated since Dash Core 0.15.0. You will be redirected to the new site at <a href="https://dashcore.readme.io">https://dashcore.readme.io</a> momentarily. <img src="/img/icons/icon_warning.svg"></img></h2>
-
-<h1>{% translate pagetitle %}</h1>
-<p class="summarytxt">{% translate summary %}</p>
-<h2 id="table-of-contents">{% translate table %}</h2>
-
-<div class="index">
-{% alphab_for v in page.voc %}
-<a href="#{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</a>
-{% endalphab_for %}
-</div>
-
-{% alphab_for v in page.voc %}
-<h2 id="{% translate {{v}} anchor.vocabulary %}">{% translate {{v}} %}</h2>
-<p>{% translate {{v}}txt %}</p>
-{% endalphab_for %}
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="https://dashcore.readme.io/docs/core-additional-resources-glossary">
+<meta http-equiv="refresh" content="0; url=https://dashcore.readme.io/docs/core-additional-resources-glossary">
+<h1>Redirecting…</h1>
+<a href="https://dashcore.readme.io/docs/core-additional-resources-glossary">Click here if you are not redirected.</a>
+<script>location="https://dashcore.readme.io/docs/core-additional-resources-glossary"</script>
+</html>

--- a/en/developer-documentation.md
+++ b/en/developer-documentation.md
@@ -13,7 +13,7 @@ end_of_page: |
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
 
-redirect_to: "https://www.dashcore.readme.io"
+redirect_to: "https://dashcore.readme.io/"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 

--- a/en/developer-documentation.md
+++ b/en/developer-documentation.md
@@ -12,6 +12,8 @@ end_of_page: |
   <script src="/js/jquery/jquery-1.11.2.min.js"></script>
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
+
+redirect_to: "https://www.dashcore.readme.io"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 

--- a/en/developer-examples.md
+++ b/en/developer-examples.md
@@ -15,6 +15,7 @@ end_of_page: |
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
   <script>updateToc();</script>
+redirect_to: "https://dashcore.readme.io/docs/core-examples-introduction"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 

--- a/en/developer-glossary.html
+++ b/en/developer-glossary.html
@@ -12,6 +12,7 @@ end_of_page: |
   <script src="/js/jquery/jquery-1.11.2.min.js"></script>
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
+redirect_to: "https://dashcore.readme.io/docs/core-additional-resources-glossary"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 

--- a/en/developer-guide.md
+++ b/en/developer-guide.md
@@ -15,6 +15,7 @@ end_of_page: |
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
   <script>updateToc();</script>
+redirect_to: "https://dashcore.readme.io/docs/core-guide-introduction"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 

--- a/en/developer-reference.md
+++ b/en/developer-reference.md
@@ -15,6 +15,7 @@ end_of_page: |
   <script src="/js/jquery/jquery-ui.min.js"></script>
   <script src="/js/devsearch.js"></script>
   <script>updateToc();</script>
+redirect_to: "https://dashcore.readme.io/docs/core-ref-introduction"
 ---
 <link rel="stylesheet" href="/css/jquery-ui.min.css">
 


### PR DESCRIPTION
This PR adds the jekyll-redirect-from plugin and uses it to redirect to the appropriate readme.io pages in a more search engine (and user) friendly way.